### PR TITLE
chore: Pass the secrets directly by removing inherits

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -8,4 +8,5 @@ jobs:
   update:
     name: Update Issue
     uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@main
-    secrets: inherit
+    secrets:
+      JIRA_URL: ${{ secrets.JIRA_URL }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,8 @@ on:
 jobs:
   check-libraries:
     uses: canonical/sdcore-github-workflows/.github/workflows/check-libraries.yaml@main
-    secrets: inherit
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
   lint-report:
     uses: canonical/sdcore-github-workflows/.github/workflows/lint-report.yaml@main
@@ -44,4 +45,5 @@ jobs:
     with:
       charm-file-name: "sdcore-webui-k8s_ubuntu-22.04-amd64.charm"
       track-name: 1.3
-    secrets: inherit
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -25,4 +25,6 @@ jobs:
     with:
       promotion: ${{ github.event.inputs.promotion }}
       track-name: ${{ github.event.inputs.track-name }}
-    secrets: inherit
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description


`secrets: inherit` does not work with dependabot. This PR passes the `CHARMCRAFT_AUTH`, `GITHUB_TOKEN` and `JIRA_URL` secrets directly to fix the workflows.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library