### PR TITLE
chore: Move to codespell and ruff

### DIFF
--- a/lib/charms/sdcore_webui_k8s/v0/sdcore_management.py
+++ b/lib/charms/sdcore_webui_k8s/v0/sdcore_management.py
@@ -112,7 +112,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 """Schemas definition for the provider and requirer sides of the `sdcore_management` interface.
@@ -146,7 +146,7 @@ class ProviderSchema(DataBagSchema):
 
 
 def data_is_valid(data: dict) -> bool:
-    """Returns whether data is valid.
+    """Return whether data is valid.
 
     Args:
         data (dict): Data to be validated.
@@ -171,13 +171,13 @@ class ManagementUrlAvailable(EventBase):
         self.management_url = management_url
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "management_url": self.management_url,
         }
 
     def restore(self, snapshot: dict) -> None:
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.management_url = snapshot["management_url"]
 
 
@@ -200,7 +200,7 @@ class SdcoreManagementRequires(Object):
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed event.
+        """Handle relation changed event.
 
         Args:
             event (RelationChangedEvent): Juju event.
@@ -215,7 +215,7 @@ class SdcoreManagementRequires(Object):
 
     @property
     def management_url(self) -> Optional[str]:
-        """Returns the address of the management endpoint.
+        """Return the address of the management endpoint.
 
         Returns:
             str: Endpoint address.
@@ -230,7 +230,7 @@ class SdcoreManagementRequires(Object):
         """Get relation data for the remote application.
 
         Args:
-            Relation: Juju relation object (optional).
+            relation: Juju relation object (optional).
 
         Returns:
             Dict: Relation data for the remote application
@@ -260,7 +260,7 @@ class SdcoreManagementProvides(Object):
         self.charm = charm
 
     def set_management_url(self, management_url: str) -> None:
-        """Sets the address of the management endpoint.
+        """Set the address of the management endpoint.
 
         Args:
             management_url (str): Configuration service address.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,24 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py310"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,7 +35,7 @@ LOGGING_RELATION_NAME = "logging"
 
 
 def _get_pod_ip() -> Optional[str]:
-    """Returns the pod IP using juju client.
+    """Return the pod IP using juju client.
 
     Returns:
         str: The pod IP.
@@ -53,7 +53,7 @@ def render_config_file(
     auth_database_name: str,
     auth_database_url: str,
 ) -> str:
-    """Renders webui configuration file based on Jinja template.
+    """Render webui configuration file based on Jinja template.
 
     Args:
         common_database_name: Common Database Name
@@ -84,7 +84,7 @@ class WebuiOperatorCharm(CharmBase):
             # NOTE: In cases where leader status is lost before the charm is
             # finished processing all teardown events, this prevents teardown
             # event code from running. Luckily, for this charm, none of the
-            # teardown code is necessary to preform if we're removing the
+            # teardown code is necessary to perform if we're removing the
             # charm.
             return
         self._container_name = self._service_name = "webui"
@@ -118,10 +118,9 @@ class WebuiOperatorCharm(CharmBase):
         self.framework.observe(self.on.config_changed, self._publish_sdcore_management_url)
 
     def _configure_webui(self, event: EventBase) -> None:
-        """Main callback function of the Webui operator.
+        """Handle config changes.
 
-        Handles config changes.
-        Manages pebble layer and Juju unit status.
+        Manage pebble layer and Juju unit status.
 
         Args:
             event: Juju event
@@ -159,7 +158,7 @@ class WebuiOperatorCharm(CharmBase):
             # NOTE: In cases where leader status is lost before the charm is
             # finished processing all teardown events, this prevents teardown
             # event code from running. Luckily, for this charm, none of the
-            # teardown code is necessary to preform if we're removing the
+            # teardown code is necessary to perform if we're removing the
             # charm.
             event.add_status(BlockedStatus("Scaling is not implemented for this charm"))
             logger.info("Scaling is not implemented for this charm")
@@ -207,7 +206,7 @@ class WebuiOperatorCharm(CharmBase):
         return service.is_running()
 
     def _get_common_database_url(self) -> str:
-        """Returns the common database url.
+        """Return the common database url.
 
         Returns:
             str: The common database url.
@@ -219,7 +218,7 @@ class WebuiOperatorCharm(CharmBase):
         ].split(",")[0]
 
     def _get_auth_database_url(self) -> str:
-        """Returns the authentication database url.
+        """Return the authentication database url.
 
         Returns:
             str: The authentication database url.
@@ -231,7 +230,7 @@ class WebuiOperatorCharm(CharmBase):
         ].split(",")[0]
 
     def _common_database_is_available(self) -> bool:
-        """Returns whether common database relation is available.
+        """Return whether common database relation is available.
 
         Returns:
             bool: Whether common database relation is available.
@@ -239,7 +238,7 @@ class WebuiOperatorCharm(CharmBase):
         return bool(self._common_database.is_resource_created())
 
     def _auth_database_is_available(self) -> bool:
-        """Returns whether authentication database relation is available.
+        """Return whether authentication database relation is available.
 
         Returns:
             bool: Whether authentication database relation is available.
@@ -247,7 +246,7 @@ class WebuiOperatorCharm(CharmBase):
         return bool(self._auth_database.is_resource_created())
 
     def _publish_sdcore_management_url(self, event: EventBase):
-        """Sets the webui url in the sdcore management relation.
+        """Set the webui url in the sdcore management relation.
 
         Passes the url of webui to sdcore management relation.
 
@@ -264,7 +263,7 @@ class WebuiOperatorCharm(CharmBase):
         )
 
     def _write_config_file(self, content: str) -> None:
-        """Writes configuration file based on provided content.
+        """Write configuration file based on provided content.
 
         Args:
             content: Configuration file content
@@ -273,11 +272,11 @@ class WebuiOperatorCharm(CharmBase):
         logger.info("Pushed %s config file", CONFIG_FILE_NAME)
 
     def _config_file_exists(self) -> bool:
-        """Returns whether the configuration file exists."""
+        """Return whether the configuration file exists."""
         return bool(self._container.exists(f"{BASE_CONFIG_PATH}/{CONFIG_FILE_NAME}"))
 
     def _relation_created(self, relation_name: str) -> bool:
-        """Returns whether a given Juju relation was crated.
+        """Return whether a given Juju relation was created.
 
         Args:
             relation_name (str): Relation name
@@ -288,7 +287,7 @@ class WebuiOperatorCharm(CharmBase):
         return bool(self.model.get_relation(relation_name))
 
     def _get_webui_endpoint_url(self) -> Optional[str]:
-        """Returns the webui endpoint url.
+        """Return the webui endpoint url.
 
         Returns:
             str: The webui endpoint url.

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,12 +1,8 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
+ruff
 types-PyYAML
 cosl

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r test-requirements.in
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -18,34 +16,27 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.2.6
+    # via -r test-requirements.in
 cosl==0.0.11
     # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==7.0.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -53,17 +44,19 @@ hvac==2.1.0
 idna==3.6
     # via requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.2
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via pytest-operator
 kubernetes==29.0.0
@@ -74,8 +67,6 @@ markupsafe==2.1.5
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
@@ -91,23 +82,19 @@ ops==2.12.0
     # via cosl
 packaging==23.2
     # via
-    #   black
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
@@ -123,14 +110,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.2.0
-    # via flake8
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -140,14 +123,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==7.0.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -161,10 +143,9 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
-    #   cosl
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
     #   pytest-operator
 requests==2.31.0
     # via
@@ -176,6 +157,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.5
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -183,8 +166,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -197,7 +178,7 @@ types-pyyaml==6.0.12.20240311
     # via -r test-requirements.in
 typing-extensions==4.10.0
     # via
-    #   cosl
+    #   -c requirements.txt
     #   mypy
     #   typing-inspect
 typing-inspect==0.9.0
@@ -210,6 +191,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   ops
 websockets==12.0

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,17 +4,16 @@
 import unittest
 from unittest.mock import patch
 
+from charm import WebuiOperatorCharm
 from ops import testing
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
-
-from charm import WebuiOperatorCharm
 
 COMMON_DATABASE_RELATION_NAME = "common_database"
 AUTH_DATABASE_RELATION_NAME = "auth_database"
 
 
 def read_file_content(path: str) -> str:
-    """Reads a file and returns as a string.
+    """Read a file and returns as a string.
 
     Args:
         path (str): path to the file.

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ description = Run static analysis checks
 setenv =
     PYTHONPATH = ""
 commands =
-    mypy {[vars]all_path} {posargs}
+    mypy {[vars]all_path} --exclude tests/unit/lib/charms/ {posargs}
 
 [testenv:unit]
 description = Run unit tests

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,8 @@ envlist = lint, static, unit
 src_path = {toxinidir}/src/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
+lib_path = {toxinidir}/lib/charms/sdcore_webui_k8s/v0/
+all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} {[vars]lib_path}
 
 [testenv]
 setenv =
@@ -28,15 +29,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library