### PR TITLE
feat: Implement provider side of `sdcore-config` interface in Webui charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -40,6 +40,8 @@ requires:
 provides:
   sdcore-management:
     interface: sdcore_management
+  sdcore-config:
+    interface: sdcore_config
 
 assumes:
   - k8s-api

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -29,3 +29,8 @@ output "sdcore_management_endpoint" {
   description = "Name of the endpoint to provide `sdcore_management` interface."
   value       = "sdcore-management"
 }
+
+output "sdcore_config_endpoint" {
+  description = "Name of the endpoint to provide `sdcore_config` interface."
+  value       = "sdcore-config"
+}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,33 +5,49 @@
 #    pip-compile --constraint=requirements.txt test-requirements.in
 #
 annotated-types==0.6.0
-    # via pydantic
+    # via
+    #   -c requirements.txt
+    #   pydantic
 asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 cachetools==5.3.3
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 certifi==2024.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 click==8.1.7
-    # via typer
+    # via
+    #   -c requirements.txt
+    #   typer
 codespell==2.2.6
     # via -r test-requirements.in
 cosl==0.0.11
-    # via -r test-requirements.in
+    # via
+    #   -c requirements.txt
+    #   -r test-requirements.in
 coverage[toml]==7.5.1
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
@@ -39,13 +55,21 @@ decorator==5.1.1
 executing==2.0.1
     # via stack-data
 google-auth==2.28.1
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 hvac==2.1.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.7
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.2
@@ -53,83 +77,118 @@ ipython==8.22.2
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 kubernetes==29.0.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 macaroonbakery==1.3.4
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
 mypy==1.10.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
+    #   -c requirements.txt
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests-oauthlib
 ops==2.13.0
     # via
+    #   -c requirements.txt
     #   cosl
     #   ops-scenario
 ops-scenario==6.0.2
-    # via pytest-interface-tester
+    # via
+    #   -c requirements.txt
+    #   pytest-interface-tester
 packaging==23.2
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 parso==0.8.3
     # via jedi
 pexpect==4.9.0
     # via ipython
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
 pyasn1==0.5.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.3.0
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 pycparser==2.21
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pydantic==2.6.4
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-interface-tester
 pydantic-core==2.16.3
-    # via pydantic
+    # via
+    #   -c requirements.txt
+    #   pydantic
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
-    # via macaroonbakery
+    # via
+    #   -c requirements.txt
+    #   macaroonbakery
 pynacl==1.5.0
     # via
+    #   -c requirements.txt
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
 pyrfc3339==1.1
     # via
+    #   -c requirements.txt
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-interface-tester
@@ -137,15 +196,22 @@ pytest==8.1.1
 pytest-asyncio==0.21.1
     # via pytest-operator
 pytest-interface-tester==2.0.1
-    # via -r test-requirements.in
+    # via
+    #   -c requirements.txt
+    #   -r test-requirements.in
 pytest-operator==0.35.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 pytz==2024.1
-    # via pyrfc3339
+    # via
+    #   -c requirements.txt
+    #   pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   cosl
     #   juju
     #   kubernetes
@@ -154,18 +220,24 @@ pyyaml==6.0.1
     #   pytest-operator
 requests==2.31.0
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
 requests-oauthlib==1.3.1
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 rsa==4.9
-    # via google-auth
+    # via
+    #   -c requirements.txt
+    #   google-auth
 ruff==0.4.4
     # via -r test-requirements.in
 six==1.16.0
     # via
+    #   -c requirements.txt
     #   asttokens
     #   kubernetes
     #   macaroonbakery
@@ -174,33 +246,44 @@ six==1.16.0
 stack-data==0.6.3
     # via ipython
 toposort==1.10
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 traitlets==5.14.1
     # via
     #   ipython
     #   matplotlib-inline
 typer==0.7.0
-    # via pytest-interface-tester
+    # via
+    #   -c requirements.txt
+    #   pytest-interface-tester
 types-pyyaml==6.0.12.20240311
     # via -r test-requirements.in
 typing-extensions==4.10.0
     # via
+    #   -c requirements.txt
     #   cosl
     #   mypy
     #   pydantic
     #   pydantic-core
     #   typing-inspect
 typing-inspect==0.9.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 urllib3==2.2.1
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   ops
 websockets==12.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju


### PR DESCRIPTION
# Description

- Integrates the provider side of `sdcore-config` library with the Webui charm.
- Removes unnecessary doc strings from some private methods
- Improves `config_changed` event handling process by calling main callback (self._configure_webui) 


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library