### PR TITLE
feat: Implement provider side of sdcore-config interface in Webui charm

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -40,6 +40,8 @@ requires:
 provides:
   sdcore-management:
     interface: sdcore_management
+  sdcore-config:
+    interface: sdcore_config
 
 assumes:
   - k8s-api

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,12 +11,15 @@ from typing import Optional
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # type: ignore[import]
 from charms.loki_k8s.v1.loki_push_api import LogForwarder  # type: ignore[import]
+from charms.sdcore_webui_k8s.v0.sdcore_config import (  # type: ignore[import]
+    SdcoreConfigProvides,
+)
 from charms.sdcore_webui_k8s.v0.sdcore_management import (  # type: ignore[import]
     SdcoreManagementProvides,
 )
 from jinja2 import Environment, FileSystemLoader
 from ops import ActiveStatus, BlockedStatus, CollectStatusEvent, ModelError, WaitingStatus
-from ops.charm import CharmBase, EventBase
+from ops.charm import CharmBase, EventBase, RelationJoinedEvent
 from ops.main import main
 from ops.pebble import Layer
 
@@ -29,6 +32,7 @@ AUTH_DATABASE_RELATION_NAME = "auth_database"
 AUTH_DATABASE_NAME = "authentication"
 COMMON_DATABASE_NAME = "free5gc"
 SDCORE_MANAGEMENT_RELATION_NAME = "sdcore-management"
+SDCORE_CONFIG_RELATION_NAME = "sdcore-config"
 GRPC_PORT = 9876
 WEBUI_URL_PORT = 5000
 LOGGING_RELATION_NAME = "logging"
@@ -103,6 +107,7 @@ class WebuiOperatorCharm(CharmBase):
         )
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
         self._sdcore_management = SdcoreManagementProvides(self, SDCORE_MANAGEMENT_RELATION_NAME)
+        self._sdcore_config = SdcoreConfigProvides(self, SDCORE_CONFIG_RELATION_NAME)
         self.unit.set_ports(GRPC_PORT, WEBUI_URL_PORT)
         self.framework.observe(self.on.webui_pebble_ready, self._configure_webui)
         self.framework.observe(self.on.common_database_relation_joined, self._configure_webui)
@@ -113,6 +118,9 @@ class WebuiOperatorCharm(CharmBase):
         self.framework.observe(self._auth_database.on.endpoints_changed, self._configure_webui)
         self.framework.observe(
             self.on.sdcore_management_relation_joined, self._configure_webui
+        )
+        self.framework.observe(
+            self.on.sdcore_config_relation_joined, self._on_sdcore_config_relation_joined
         )
         # Handling config changed event to publish the new url if the unit reboots and gets new IP
         self.framework.observe(self.on.config_changed, self._configure_webui)
@@ -146,7 +154,7 @@ class WebuiOperatorCharm(CharmBase):
 
         self._configure_workload(restart=config_update_required)
         self._publish_sdcore_management_url()
-
+        self._publish_sdcore_config_url()
 
     def _on_collect_unit_status(self, event: CollectStatusEvent):
         """Check the unit status and set to Unit when CollectStatusEvent is fired.
@@ -202,6 +210,29 @@ class WebuiOperatorCharm(CharmBase):
             auth_database_name=AUTH_DATABASE_NAME,
             auth_database_url=self._get_auth_database_url(),
         )
+
+    def _on_sdcore_config_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Handle sdcore_config relation joined event.
+
+        Set the Webui config URL in the relation databag when Webui becomes accessible.
+
+        Args:
+            event: RelationJoinedEvent
+        """
+        if not self._webui_service_is_running():
+            return
+
+        webui_config_url = self._get_webui_config_url()
+        self._sdcore_config.set_webui_url(
+            webui_url=webui_config_url,
+            relation_id=event.relation.id,
+        )
+
+    def _publish_sdcore_config_url(self) -> None:
+        if not self._relation_created(SDCORE_CONFIG_RELATION_NAME):
+            return
+        webui_config_url = self._get_webui_config_url()
+        self._sdcore_config.set_webui_url_in_all_relations(webui_url=webui_config_url)
 
     def _configure_workload(self, restart: bool = False) -> None:
         """Configure and restart the workload if required.
@@ -295,6 +326,9 @@ class WebuiOperatorCharm(CharmBase):
         if not _get_pod_ip():
             return None
         return f"http://{_get_pod_ip()}:{WEBUI_URL_PORT}"
+
+    def _get_webui_config_url(self) -> str:
+        return f"{self._service_name}:{GRPC_PORT}"
 
     @property
     def _pebble_layer(self) -> Layer:

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -29,3 +29,8 @@ output "sdcore_management_endpoint" {
   description = "Name of the endpoint to provide `sdcore_management` interface."
   value       = "sdcore-management"
 }
+
+output "sdcore_config_endpoint" {
+  description = "Name of the endpoint to provide `sdcore_config` interface."
+  value       = "sdcore-config"
+}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from unittest.mock import Mock, call, patch
+from unittest.mock import call, patch
 
 import pytest
 from charm import WebuiOperatorCharm
@@ -29,9 +29,6 @@ class TestCharm:
         "charms.sdcore_webui_k8s.v0.sdcore_management.SdcoreManagementProvides.set_management_url"
     )
     patcher_get_service = patch("ops.model.Container.get_service")
-    patcher_set_webui_url = patch(
-        "charms.sdcore_webui_k8s.v0.sdcore_config.SdcoreConfigProvides.set_webui_url"
-    )
     patcher_set_webui_url_in_all_relations = patch(
         "charms.sdcore_webui_k8s.v0.sdcore_config.SdcoreConfigProvides.set_webui_url_in_all_relations"
     )
@@ -41,7 +38,6 @@ class TestCharm:
         self.mock_check_output = TestCharm.patcher_check_output.start()
         self.mock_set_management_url = TestCharm.patcher_set_management_url.start()
         self.mock_get_service = TestCharm.patcher_get_service.start()
-        self.mock_set_webui_url = TestCharm.patcher_set_webui_url.start()
         self.mock_set_webui_url_in_all_relations = TestCharm.patcher_set_webui_url_in_all_relations.start()  # noqa: E501
 
     @staticmethod
@@ -332,33 +328,42 @@ class TestCharm:
             management_url=f"http://{pod_ip}:5000",
         )
 
-    def test_given_webui_service_is_running_db_relations_are_joined_and_sdcore_config_relation_is_joined_when_config_changed_then_config_url_is_published_for_all_relations(  # noqa: E501
+    def test_given_storage_not_attached_when_sdcore_config_relation_is_created_then_config_url_is_not_published_for_relations(  # noqa: E501
         self,
+    ):
+        self.harness.set_can_connect(container=CONTAINER, val=True)
+        self.harness.add_storage("config", attach=False)
+        self._create_common_database_relation_and_populate_data()
+        self._create_auth_database_relation_and_populate_data()
+        self._create_sdcore_config_relation("requirer")
+        self.mock_set_webui_url_in_all_relations.assert_not_called()
+
+    def test_given_webui_service_is_running_db_relations_are_not_joined_when_sdcore_config_relation_is_joined_then_config_url_is_not_published_for_relations(  # noqa: E501
+        self,
+    ):
+        self.harness.set_can_connect(container=CONTAINER, val=True)
+        self.harness.add_storage("config", attach=True)
+        self.mock_get_service.side_effect = None
+        self._create_sdcore_config_relation("requirer")
+        self.mock_set_webui_url_in_all_relations.assert_not_called()
+
+    def test_given_webui_service_is_running_db_relations_are_not_joined_when_several_sdcore_config_relations_are_joined_then_config_url_is_set_in_all_relations(  # noqa: E501
+        self
     ):
         self.harness.set_can_connect(container=CONTAINER, val=True)
         self.harness.add_storage("config", attach=True)
         self.mock_get_service.side_effect = None
         self._create_common_database_relation_and_populate_data()
         self._create_auth_database_relation_and_populate_data()
-        self._create_sdcore_config_relation("requirer")
-        self.harness.charm._configure_webui(Mock())
-        self.mock_set_webui_url_in_all_relations.assert_called_once_with(webui_url="webui:9876")
-
-    def test_given_webui_service_is_running_when_several_sdcore_config_relations_are_joined_then_config_url_is_set_in_all_relations(  # noqa: E501
-        self
-    ):
-        self.harness.set_can_connect(container=CONTAINER, val=True)
-        self.harness.add_storage("config", attach=True)
-        self.mock_get_service.side_effect = None
         relation_id_1 = self.harness.add_relation(SDCORE_CONFIG_RELATION_NAME, "requirer1")
         self.harness.add_relation_unit(relation_id=relation_id_1, remote_unit_name="requirer1")
         relation_id_2 = self.harness.add_relation(SDCORE_CONFIG_RELATION_NAME, "requirer2")
         self.harness.add_relation_unit(relation_id=relation_id_2, remote_unit_name="requirer2")
         calls = [
-            call.emit(webui_url="webui:9876", relation_id=relation_id_1),
-            call.emit(webui_url="webui:9876", relation_id=relation_id_2),
+            call.emit(webui_url="webui:9876"),
+            call.emit(webui_url="webui:9876"),
         ]
-        self.mock_set_webui_url.assert_has_calls(calls)
+        self.mock_set_webui_url_in_all_relations.assert_has_calls(calls)
 
     def test_given_webui_service_is_not_running_when_sdcore_config_relation_joined_then_config_url_is_not_set_in_the_relations(  # noqa: E501
         self,
@@ -367,7 +372,7 @@ class TestCharm:
         self.harness.add_storage("config", attach=True)
         self.mock_get_service.side_effect = ModelError()
         self._create_sdcore_config_relation(requirer="requirer1")
-        self.mock_set_webui_url.assert_not_called()
+        self.mock_set_webui_url_in_all_relations.assert_not_called()
 
     def test_given_common_db_relation_is_created_but_not_available_when_collect_status_then_status_is_waiting(  # noqa: E501
         self,


### PR DESCRIPTION
# Description

Integrates the provider side of `sdcore-config` library with the Webui charm.
Fixing `def _relation_created` method which was raising TooManyRelatedAppsError (https://github.com/canonical/operator/blob/9e5463cde7d942d71cd51af467d832759728480b/ops/model.py#L933) when  several  requirers join through `sdcore_config` interface.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x ] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library